### PR TITLE
Export `io.github.chrimle.exceptionfactory` Module

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+/** Create {@code Exception}-instances with Factory-methods and Builder patterns! */
+module io.github.chrimle.exceptionfactory {
+  // Exports
+  exports io.github.chrimle.exceptionfactory;
+
+  // Requires (static)
+  requires static org.jetbrains.annotations;
+  requires static org.jspecify;
+}


### PR DESCRIPTION
> Modularizes the project and exports it as `io.github.chrimle.exceptionfactory`. **NOTE**: This is **MAY** be a **breaking change**, if the default `exception.factory` module name is used. If so, rename the `require` to use the new official module name.